### PR TITLE
fix: 使用者無法執行最新版本的檔案

### DIFF
--- a/general/models.py
+++ b/general/models.py
@@ -1,5 +1,4 @@
 from django.db import models
 
-# Create your models here.
 class FileModel(models.Model):
 	file = models.FileField(upload_to = 'upload')

--- a/general/views.py
+++ b/general/views.py
@@ -18,19 +18,23 @@ class FileView(View):
         files = request.FILES.getlist('file')
         referer = request.META.get('HTTP_REFERER')
         caller = referer.split('/')[3] # url like http://127.0.0.1:8000/[caller]/
-        file_path = 'upload/'+caller+'/'
+        root_path = 'upload/'+caller+'/'
         finlish = False
         if form.is_valid():
             for f in files:
-                self.handle_upload_file(f, file_path) 
+                self.handle_upload_file(f, root_path) 
             finlish = True
             return JsonResponse(finlish, safe=False)
         else:
             form = UploadFileForm()
                 
-    def handle_upload_file(self, f, file_path):
+    def handle_upload_file(self, f, root_path):
         fs = FileSystemStorage()
-        fs.save(file_path+f.name.split(".")[-2]+'/'+f.name, f)
+        directory_path = root_path+f.name.split(".")[-2]+'/'
+        file_path = directory_path+f.name
+        if fs.exists(file_path):
+            fs.delete(file_path)
+        fs.save(file_path, f)
         
 class ExecuteView(View):
     def get(self, request, *arg, **kwargs):

--- a/json_parser/views.py
+++ b/json_parser/views.py
@@ -48,18 +48,18 @@ class JsonFileView(FileView):
         files = request.FILES.getlist('file')
         referer = request.META.get('HTTP_REFERER')
         caller = referer.split('/')[3] # url like http://127.0.0.1:8000/[caller]/
-        file_path = 'upload/'+caller+'/'
+        root_path = 'upload/'+caller+'/'
         finlish = True
         if form.is_valid():
             for f in files:
-                self.handle_upload_file(f, file_path)
+                self.handle_upload_file(f, root_path)
                 element_dict = parser.get_file_string_element\
-                    (file_path+f.name.split(".")[-2]+'/'+f.name)
+                    (root_path+f.name.split(".")[-2]+'/'+f.name)
                 if element_dict:
                     finlish = False
             if finlish:
                 for f in files:
-                    parser.create_json_file(file_path, f.name, {}, {})
+                    parser.create_json_file(root_path, f.name, {}, {})
             return JsonResponse(finlish, safe=False)
         else:
             form = UploadFileForm()


### PR DESCRIPTION
問題：
1. 使用者上傳同名檔案時，系統將取新的檔名
2. 執行檔案時，只會執行原始檔名的檔案

原因：
1. 使用了FileSystemStorage預設的存檔機制
2. 執行檔案時只抓取資料夾名稱作為想執行的對象

調整項目：
1. views在儲存檔案前，會先檢查是否有同名檔案

issue #37