### PR TITLE
hotfix: 增加下載後檔案的辨識度

### DIFF
--- a/general/views.py
+++ b/general/views.py
@@ -99,11 +99,12 @@ class DownloadView(View):
     def get(self, request, *arg, **kwargs):
         name = request.GET.get('File',None)
         directory_name = name.split(".")[-2]
+        name = directory_name + '_output.csv'
         referer = request.META.get('HTTP_REFERER')
         caller = referer.split('/')[3] # url like http://127.0.0.1:8000/[caller]/
-        file_path = 'output/'+caller+'/'+directory_name+'/'+directory_name+'_output.csv'
+        file_path = 'output/'+caller+'/'+directory_name+'/'+name
         df = pd.read_csv(file_path)
         response = HttpResponse(content_type="text/csv")
-        response['Content-Disposition'] = 'attachment; filename=%s' %name
+        response['Content-Disposition'] = 'attachment; filename=%s' %caller+'_'+name
         df.to_csv(path_or_buf=response,index=False,decimal=",")
         return response


### PR DESCRIPTION
問題：
1. 下載後只有檔名，使用者連檔案有沒有經過處理都難以分辨

調整項目：
1. 下載檔名增加output以方便識別
2. 下載檔名增加處理方式名稱，讓使用者便於區分成效

issue #51