### PR TITLE
hotfix: 超過檔案限制的檔案不該能夠上傳

### DIFF
--- a/Template/general/function_home.html
+++ b/Template/general/function_home.html
@@ -66,6 +66,14 @@
             </div>
         </div>
         <script>
+            function isValidFile(file) {
+                var type = "." + file.value.split(".")[1];
+                if (type == file.accept) {
+                    return true;
+                }
+                return false;
+            }
+        
             $("#customFile_csv").on("change", function() {
                 var fileName = $(this).val().split("\\").pop();
                 $(this).siblings(".custom-file-label").addClass("selected").html(fileName);
@@ -73,24 +81,33 @@
             const selectElement = document.querySelector('#customFile_csv');
                 selectElement.addEventListener('change', (event) => {
                     let formData = new FormData($('#form_file').get(0));
-                    $.ajax({
-                        url: '/{% block title_preview %}title{% endblock title_preview %}/Web_View_CSV/',
-                        type: 'POST',
-                        data: formData,
-                        dataType: 'json',
-                        contentType: false,
-                        processData: false,
-                        success: function (tables) {
-                            $('#showText').html(tables);
-                            alert("您的檔案已可預覽及上傳");
-                        },
-                        error: function (xhr, ajaxOptions, thrownError) {
-                            alert(xhr.status);
-                            var jsonObj = JSON.parse(xhr.responseText);
-                            alert(jsonObj.status +"：\n" + jsonObj.message );
-                        }
-                    });
+                    $('#btn_preview').attr('disabled', 'disabled');
+                    $('#btn_upload_file').attr('disabled', 'disabled');
+                    if (isValidFile(document.getElementById('customFile_csv'))) {
+                        $.ajax({
+                            url: '/{% block title_preview %}title{% endblock title_preview %}/Web_View_CSV/',
+                            type: 'POST',
+                            data: formData,
+                            dataType: 'json',
+                            contentType: false,
+                            processData: false,
+                            success: function (tables) {
+                                $('#showText').html(tables);
+                                alert("您的檔案已可預覽及上傳");
+                                $('#btn_preview').removeAttr('disabled');
+                                $('#btn_upload_file').removeAttr('disabled');
+                            },
+                            error: function (xhr, ajaxOptions, thrownError) {
+                                var jsonObj = JSON.parse(xhr.responseText);
+                                alert(jsonObj.status +"：\n" + jsonObj.message );
+                            }
+                        });
+                    }
+                    else {
+                        alert("檔案類型錯誤");
+                    }
                 });
+                
             $('#btn_upload_file').click( function () {
                 var csv_name = document.getElementById('customFile_csv').value;
                 csv_name = csv_name.split("\\").pop()
@@ -118,7 +135,6 @@
                             {% endblock upload_success %}
                         },
                         error: function (xhr, ajaxOptions, thrownError) {
-                            alert(xhr.status);
                             alert(thrownError);
                         }
                     });


### PR DESCRIPTION
問題：
1. 超過大小限制的檔案能夠上傳
2. 非 csv 檔能夠上傳

原因：
1. 觸發檢查後，上傳按鈕沒有鎖住，導致能夠上傳
2. html只有提供選擇檔案時，排除csv檔以外的檔案
3. 使用者可以藉由選擇全部檔案類型，來選擇csv檔以外的檔案

調整項目：
1. 當選擇csv檔時，鎖住預覽及上傳按鈕
2. 如果檔案通過檢查，才會解鎖預覽及上傳按鈕
3. 透過javascript檢查副檔名是否為csv

issue #48