### PR TITLE
hotfix: 執行頁面連結錯誤

### DIFF
--- a/Template/k_Anonymity/k_Anonymity.html
+++ b/Template/k_Anonymity/k_Anonymity.html
@@ -1,7 +1,7 @@
 {% extends "general/function.html" %}
 {% block title %}k-Anonymity{% endblock title %}
-{% block output_path %}k-Anonymity{% endblock output_path %}
-{% block home_path %}k-Anonymity{% endblock home_path %}
+{% block output_path %}k_Anonymity{% endblock output_path %}
+{% block home_path %}k_Anonymity{% endblock home_path %}
 {% block content %}
     <h2>k-Anonymity</h2>
     <h5 style="font-weight:bold;color:red">說明1：將滑鼠移至欄位上可查看欄位說明</h5>

--- a/Template/l_Diversity/l_Diversity.html
+++ b/Template/l_Diversity/l_Diversity.html
@@ -1,7 +1,7 @@
 {% extends "general/function.html" %}
 {% block title %}l-Diversity{% endblock title %}
-{% block output_path %}l-Diversity{% endblock output_path %}
-{% block home_path %}l-Diversity{% endblock home_path %}
+{% block output_path %}l_Diversity{% endblock output_path %}
+{% block home_path %}l_Diversity{% endblock home_path %}
 {% block content %}
     <h2>l-Diversity</h2>
     <h5 style="font-weight:bold;color:red">說明1：將滑鼠移至欄位上可查看欄位說明</h5>

--- a/Template/navbar.html
+++ b/Template/navbar.html
@@ -20,7 +20,7 @@
                 <a class="navbar-brand" href="{% url 'logout' %}" style="color:#ffffff">登出</a>
             </li>
             <li class="nav-item">
-                <a type="button" class="navbar-brand" id="delete_account" style="color:#ffffff">刪除帳號</a>
+                <a class="navbar-brand" href="javascript:void(0)" id="delete_account" style="color:#ffffff">刪除帳號</a>
             </li>
         </ul>
     </nav>

--- a/Template/t_Closeness/t_Closeness.html
+++ b/Template/t_Closeness/t_Closeness.html
@@ -1,7 +1,7 @@
 {% extends "general/function.html" %}
 {% block title %}t-Closeness{% endblock title %}
-{% block output_path %}t-Closeness{% endblock output_path %}
-{% block home_path %}t-Closeness{% endblock home_path %}
+{% block output_path %}t_Closeness{% endblock output_path %}
+{% block home_path %}t_Closeness{% endblock home_path %}
 {% block content %}
     <h2>t-Closeness</h2>
     <h5 style="font-weight:bold;color:red">說明1：將滑鼠移至欄位上可查看欄位說明</h5>


### PR DESCRIPTION
問題：
1. 執行頁面的連結錯誤
2. 刪除帳號的按鈕在不同瀏覽器上有所差異

原因：
1. 標題名稱是-，但是連結是_，當初直接複製所以連結錯誤
2. 刪除帳號想要用javascript處理，又用button維持游標形狀

調整項目：
1. 各執行頁面的連結調整回正常的連結網址
2. 改為和其他人一樣的<a>標籤，並用javascript:void(0)來維持游標形狀