### PR TITLE
hotfix: 修復區間設定錯誤

### DIFF
--- a/Template/general/advanced_number_preprocessing.html
+++ b/Template/general/advanced_number_preprocessing.html
@@ -37,10 +37,11 @@
         document.getElementById(number_title+'_interval').style.display = 'block'
         var interval_area = document.getElementById(number_title+'_interval_tbody');
         var interval_quantity = interval_area.rows.length+1;
+        var number_type_pair = {{ number_type_pair | safe }};
         var base = {{ min_value_dict | safe }};
         var max = {{ max_value_dict | safe }};
         
-        base = base[number_title]
+        base = base[number_title];
         bias = (max[number_title] - base)/interval_quantity;
         
         var i;
@@ -52,12 +53,20 @@
         interval_area.innerHTML = ""
         
         for (i=0; i<interval_quantity; i++) {
+            var now_value = base+(bias*i);
+            var next_value  = base+(bias*(i+1));
+            
+            if (number_type_pair[number_title] == 'int') {
+                now_value = Math.round(now_value);
+                next_value = Math.round(next_value);
+            }
+        
             tr = interval_area.insertRow(-1);
             td = tr.insertCell(-1);
             temp = '';
-            temp += '<input type="number" value="'+(base+(bias*i))+'" class="'+number_title+'_interval_'+i+'" required>'
+            temp += '<input type="number" value="'+now_value+'" class="'+number_title+'_interval_'+i+'" required>'
             temp += '--';
-            temp += '<input type="number" value="'+(base+(bias*(i+1)))+'" class="'+number_title+'_interval_'+(i+1)+'" required>';
+            temp += '<input type="number" value="'+next_value+'" class="'+number_title+'_interval_'+(i+1)+'" required>';
             if (i==interval_quantity-1) {
                 temp += '<img id="'+number_title+'_icon_'+i+'" src="{% static "img/plus.png" %}" alt="{% trans "新增區間" %}" width="40" onclick="add_interval(\''+number_title+'\')"/>';
             } else {
@@ -93,30 +102,49 @@
     }
     
     function interval_check(interval_temp, number_title, i) {
-        var value = interval_temp.value;
+        var number_type_pair = {{ number_type_pair | safe }};
+        var value;
         var previous_value;
         var next_value;
         var error_message;
         interval_quantity = document.getElementById(number_title+'_interval_tbody').rows.length;
+        
+        if (number_type_pair[number_title] == 'int') {
+            value = parseInt(interval_temp.value);
+            if (i != 0) {
+                previous_value = parseInt(document.getElementsByClassName(number_title+'_interval_'+(i-1))[0].value);
+            }
+            if (i != interval_quantity) {
+                next_value = parseInt(document.getElementsByClassName(number_title+'_interval_'+(i+1))[0].value);
+            }
+        }
+        else if (number_type_pair[number_title] == 'float') {
+            value = parseFloat(interval_temp.value);
+            if (i != 0) {
+                previous_value = parseFloat(document.getElementsByClassName(number_title+'_interval_'+(i-1))[0].value);
+            }
+            if (i != interval_quantity) {
+                next_value = parseFloat(document.getElementsByClassName(number_title+'_interval_'+(i+1))[0].value);
+            }
+        }
+        else {
+            error_message = "number_type_pair + {% trans '錯誤，請聯絡開發人員' %} + : " + number_type_pair[number_title];
+        }
+        
         if (i == 0) {
             var min_value = {{ min_value_dict | safe }};
             min_value = min_value[number_title];
-            next_value = document.getElementsByClassName(number_title+'_interval_'+(i+1))[0].value;
-            if (next_value > min_value) {
+            if (next_value >= min_value) {
                 next_value = min_value;
                 error_message = "{% trans '無法大於欄位最小值' %}";
             }
         } else if (i == interval_quantity) {
             var max_value = {{ max_value_dict | safe }};
             max_value = max_value[number_title];
-            previous_value = document.getElementsByClassName(number_title+'_interval_'+(i-1))[0].value;
-            if (previous_value < max_value) {
+            if (previous_value <= max_value) {
                 previous_value = max_value;
                 error_message = "{% trans '無法小於欄位最大值' %}";
             }
-        } else {
-            next_value = document.getElementsByClassName(number_title+'_interval_'+(i+1))[0].value;
-            previous_value = document.getElementsByClassName(number_title+'_interval_'+(i-1))[0].value;
         }
         
         close_alert();

--- a/Template/general/update_log.html
+++ b/Template/general/update_log.html
@@ -7,6 +7,8 @@
         <h4 style="font-weight:bold;color:red">{% trans '調整項目：' %}</h5>
         <h5 style="font-weight:bold;color:red">{% trans '1. 修復非地址的欄位，在選擇欄位關係為地址後，沒有出現警告的問題' %}</h5>
         <h5 style="font-weight:bold;color:red">{% trans '2. 修復連續觸發 alert 時，淡出效果不會重置的問題' %}</h5>
+        <h5 style="font-weight:bold;color:red">{% trans '3. 修復當欄位中有空值時，區間設定將會錯誤運作' %}</h5>
+        <h5 style="font-weight:bold;color:red">{% trans '4. 修復自動生成區間時，會導致整數類型的欄位被解讀為浮點數' %}</h5>
     </cell>
     <cell cell_title="{9/1 ver 1.4.2">
         <h4 style="font-weight:bold;color:red">{% trans '調整項目：' %}</h5>

--- a/general/views.py
+++ b/general/views.py
@@ -57,7 +57,7 @@ class FileView(View):
         upload_form = FileModel()
         upload_form.file = file
         try:
-            df = pd.read_csv(upload_form.file)
+            df = pd.read_csv(upload_form.file, dtype=str)
             if df.isnull().values.any():
                 return JsonResponse({'message':gettext('此方法檔案中不能有空欄，請改為使用 DPView 進行去識別化')}, status=400)
         except UnicodeDecodeError as e:
@@ -73,7 +73,7 @@ class FileView(View):
         upload_form = FileModel()
         upload_form.file = file
         try:
-            df = pd.read_csv(upload_form.file)
+            df = pd.read_csv(upload_form.file, dtype=str)
             if df.isnull().values.any():
                 return JsonResponse({'message':gettext('此方法檔案中不能有空欄，請改為使用 DPView 進行去識別化')}, status=400)
         except UnicodeDecodeError as e:
@@ -90,7 +90,7 @@ class FileView(View):
         upload_form = FileModel()
         upload_form.file = file
         try:
-            df = pd.read_csv(upload_form.file)
+            df = pd.read_csv(upload_form.file, dtype=str)
         except UnicodeDecodeError as e:
             return JsonResponse({'message':gettext('檔案編碼錯誤，請確保檔案由UTF-8編碼')}, status=400)
         if(df.shape[1] >= 3):

--- a/json_parser/json_parser.py
+++ b/json_parser/json_parser.py
@@ -6,54 +6,21 @@ import re
 import pandas as pd
 from django.utils.translation import gettext
 from general.exception import NotAddressException
+from general.function import ContentDetection
 
 class JsonParser():
-    
+
     __n_parts = 10
     __float_accuracy = 4
     __tw_address_accuracy_pattern = '縣市鄉鎮市區街路村里巷弄號樓室'
-
-    def is_string(self, item_list):
-        if not item_list:
-            return False
-        for item in item_list:
-            if not item:
-                continue                
-            try:
-                float(item)
-                return False
-            except ValueError:
-                return True
-        
-    def is_number(self, item_list):
-        if not item_list:
-            return False
-        for item in item_list:
-            if not item:
-                continue                
-            try:
-                float(item)
-                return True
-            except ValueError:
-                return False
-    
-    def is_float(self, item_list):
-        if not self.is_number(item_list):
-            return False
-        for item in item_list:
-            if not item:
-                continue
-            if type(item) is float:
-                return True
-            if type(item) is str and item.find('.'):
-                return True            
     
     def get_interval(self, number_list):
-        if not self.is_number(number_list):
+        detection = ContentDetection()
+        if not detection.is_number(number_list):
             raise TypeError(number_list + 'is not number list')
         number_list = list(filter(None, number_list))
-        
-        if(self.is_float(number_list)):
+        number_list_is_float = detection.is_float(number_list)
+        if number_list_is_float:
             min_value = float(min(number_list))
             max_value = float(max(number_list))
         else:
@@ -61,14 +28,17 @@ class JsonParser():
             max_value = int(max(number_list))
             
         interval = []
-        if(self.is_float(number_list)):
-            gap = (max_value - min_value) / self.__n_parts
+        gap = (max_value - min_value) / self.__n_parts
+        if number_list_is_float:
+            for i in range(self.__n_parts):
+                upper_limit = round(min_value + gap*(i+1), self.__float_accuracy)
+                lower_limit = round(min_value + gap*i, self.__float_accuracy)
+                interval.append([lower_limit, upper_limit])
         else:
-            gap = math.ceil((max_value - min_value) / self.__n_parts)
-        for i in range(self.__n_parts):
-            upper_limit = round(min_value + gap*(i+1), self.__float_accuracy)
-            lower_limit = round(min_value + gap*i, self.__float_accuracy)
-            interval.append([lower_limit, upper_limit])
+            for i in range(self.__n_parts):
+                upper_limit = round(min_value + gap*(i+1))
+                lower_limit = round(min_value + gap*i)
+                interval.append([lower_limit, upper_limit])
         return interval
         
     def get_unrelated_structure(self, string_list, ancestor):
@@ -118,7 +88,8 @@ class JsonParser():
         return genealogy
     
     def get_column_element(self, column):
-        if self.is_string(column):
+        detection = ContentDetection()
+        if detection.is_string(column):
             return list(filter(None, list(set(column))))
         else:
             return None
@@ -134,7 +105,9 @@ class JsonParser():
                 
     def parser_to_json(self, file_path, structure, **kwargs):
         json_dict = {}
+        detection = ContentDetection()
         dataframe = pd.read_csv(file_path, keep_default_na=False)
+        print(dataframe)
         number_title_pair_dict = None
         interval_dict = None
         if 'number_title_pair_dict' in kwargs:
@@ -143,15 +116,15 @@ class JsonParser():
         for column_title in dataframe:
             temp = {}
             column = dataframe.loc[:, column_title].values.tolist()
-            if self.is_string(column):
+            if detection.is_string(column):
                 temp['type'] = 'categorical'
                 temp['structure'] = structure[column_title]
-            elif self.is_number(column):
+            elif detection.is_number(column):
                 temp['type'] = 'numerical'
                 temp['min'] = min(column)
                 temp['max'] = max(column)
                 
-                if self.is_float(column):
+                if detection.is_float(column):
                     temp['num_type'] = 'float'
                 else:
                     temp['num_type'] = 'int'
@@ -172,6 +145,7 @@ class JsonParser():
     
     def parser_to_DPView_json(self, file_path, pair_dict, **kwargs):
         json_dict = {}
+        detection = ContentDetection()
         dataframe = pd.read_csv(file_path, keep_default_na=False)
         interval_dict = None
         if 'interval_dict' in kwargs:
@@ -179,9 +153,9 @@ class JsonParser():
         for column_title in dataframe:
             temp = {}
             column = dataframe.loc[:, column_title].values.tolist()
-            if self.is_string(column):
+            if detection.is_string(column):
                 temp['type'] = 'cat'
-            elif self.is_number(column):
+            elif detection.is_number(column):
                 if pair_dict[column_title] == 'number':
                     temp['type'] = 'num'
                 elif pair_dict[column_title] == 'single':

--- a/json_parser/tests.py
+++ b/json_parser/tests.py
@@ -38,36 +38,15 @@ class TestParser(unittest.TestCase):
         else:
             print("Test file is deleted successfully")
     
-    def test_is_string(self):
-        self.assertTrue(self.json_parser.is_string(self.categorical))
-        self.assertFalse(self.json_parser.is_string(self.number_int))
-        self.assertFalse(self.json_parser.is_string(self.number_float))
-        self.assertFalse(self.json_parser.is_string(self.mixing))
-        self.assertFalse(self.json_parser.is_string(self.empty))
-
-    def test_is_number(self):
-        self.assertFalse(self.json_parser.is_number(self.categorical))
-        self.assertTrue(self.json_parser.is_number(self.number_int))
-        self.assertTrue(self.json_parser.is_number(self.number_float))
-        self.assertFalse(self.json_parser.is_number(self.mixing))
-        self.assertFalse(self.json_parser.is_number(self.empty))
-        
-    def test_is_float(self):
-        self.assertFalse(self.json_parser.is_float(self.categorical))
-        self.assertFalse(self.json_parser.is_float(self.number_int))
-        self.assertTrue(self.json_parser.is_float(self.number_float))
-        self.assertFalse(self.json_parser.is_float(self.mixing))
-        self.assertFalse(self.json_parser.is_float(self.empty))
-    
     def test_calculate_interval(self):
         number_int_interval = self.json_parser.get_interval(self.number_int)
         number_float_interval = self.json_parser.get_interval(self.number_float)
         
-        test_int_interval = [[1,35],[35,69],\
-                            [69,103],[103,137],\
-                            [137,171],[171,205],\
-                            [205,239],[239,273],\
-                            [273,307],[307,341]]
+        test_int_interval = [[1,34],[34,67],\
+                            [67,101],[101,134],\
+                            [134,167],[167,200],\
+                            [200,233],[233,267],\
+                            [267,300],[300,333]]
         
         test_float_interval = [[1.1,34.3233],[34.3233,67.5466],\
                                 [67.5466,100.7699],[100.7699,133.9932],\
@@ -204,11 +183,11 @@ class TestParser(unittest.TestCase):
                             'min':1, 
                             'max':333, 
                             'num_type':'int',
-                            'interval':[[1,35],[35,69],\
-                            [69,103],[103,137],\
-                            [137,171],[171,205],\
-                            [205,239],[239,273],\
-                            [273,307],[307,341]]
+                            'interval':[[1,34],[34,67],\
+                            [67,101],[101,134],\
+                            [134,167],[167,200],\
+                            [200,233],[233,267],\
+                            [267,300],[300,333]]
                         },
                         'String2':{
                             'type':'categorical',

--- a/json_parser/views.py
+++ b/json_parser/views.py
@@ -107,17 +107,33 @@ class DPViewParserView(View):
         
 class CustomView(View):
     @method_decorator(login_required)
-    def get(self, request, *arg, **kwargs):
-        parser = JsonParser()
-        path = Path()
-        
-        string_element_dict = {} # column_title - element
-        
+    def get(self, request, *arg, **kwargs):        
         file_name = kwargs.get('csv_name')
         if not file_name:
             return redirect('home')
         alert_message = kwargs.get('alert_message')
-            
+         
+        request_dict = self.get_request_dict(request, *arg, **kwargs)
+        request_dict['alert_message'] = alert_message
+        return render(request, 'general/parameter_custom.html', request_dict)
+        
+    @method_decorator(login_required)
+    def post(self, request, *arg, **kwargs):
+        file_name = kwargs.get('csv_name')
+        if not file_name:
+            return redirect('home')
+        title_id_pair = request.POST.get('title_id_pair', None)
+        
+        request_dict = self.get_request_dict(request, *arg, **kwargs)
+        request_dict['title_id_pair'] = title_id_pair
+        return render(request, 'general/parameter_custom.html', request_dict)
+    
+    def get_request_dict(self, request, *arg, **kwargs):
+        parser = JsonParser()
+        path = Path()
+        
+        string_element_dict = {} # column_title - element        
+        file_name = kwargs.get('csv_name')            
         caller = path.get_caller(request)
             
         file_path = path.get_upload_path(request, file_name, caller=caller)
@@ -125,39 +141,12 @@ class CustomView(View):
               
         request_dict = {}  
         request_dict = self.set_url_path(request_dict, caller, file_name)
-        request_dict['alert_message'] = alert_message
         request_dict['string_element_dict'] = string_element_dict
         request_dict['caller'] = caller
         request_dict['file_name'] = file_name
         request_dict['custom_mode'] = 'json_parser'
-        return render(request, 'general/parameter_custom.html', request_dict)
-        
-    @method_decorator(login_required)
-    def post(self, request, *arg, **kwargs):
-        parser = JsonParser()
-        path = Path()
-        
-        string_element_dict = {} # column_title - element
-        
-        file_name = kwargs.get('csv_name')
-        if not file_name:
-            return redirect('home')
-        title_id_pair = request.POST.get('title_id_pair', None)
-            
-        caller = path.get_caller(request)
-            
-        file_path = path.get_upload_path(request, file_name, caller=caller)
-        string_element_dict = parser.get_file_string_element(file_path)
-              
-        request_dict = {}  
-        request_dict = self.set_url_path(request_dict, caller, file_name)        
-        request_dict['string_element_dict'] = string_element_dict
-        request_dict['caller'] = caller
-        request_dict['title_id_pair'] = title_id_pair
-        request_dict['file_name'] = file_name
-        request_dict['custom_mode'] = 'json_parser'
-        return render(request, 'general/parameter_custom.html', request_dict)
-        
+        return request_dict
+    
     def set_url_path(self, request_dict, caller, file_name):
         request_dict['create_json'] = reverse(caller+':create_json')
         request_dict['title_check'] = reverse(caller+':title_check')
@@ -170,62 +159,42 @@ class CustomView(View):
 class AdvancedSettingsView(CustomView):
     @method_decorator(login_required)
     def get(self, request, *arg, **kwargs):
-        parser = JsonParser()
-        path = Path()
-        number_data_frame = NumberDataframe()
-        
-        string_element_dict = {} # column_title - element
-        username = request.user.get_username()
         file_name = kwargs.get('csv_name')
-        alert_message = kwargs.get('alert_message')
+        if not file_name:
+            return redirect('home')
             
-        caller = path.get_caller(request)
-        
-        file_path = path.get_upload_path(request, file_name, caller=caller)
-        string_element_dict = parser.get_file_string_element(file_path)
-        number_title_list = number_data_frame.get_number_title(file_path)
-        max_value_dict, min_value_dict = number_data_frame.get_number_limit(file_path, number_title_list)
-           
-        request_dict = {}
-        request_dict = self.set_url_path(request_dict, caller, file_name)
+        alert_message = kwargs.get('alert_message')
+        request_dict = self.get_request_dict(request, *arg, **kwargs)
         request_dict['alert_message'] = alert_message
-        request_dict['string_element_dict'] = string_element_dict
-        request_dict['file_name'] = file_name
-        request_dict['custom_mode'] = 'json_parser'
-        request_dict['caller'] = caller
-        request_dict['advanced_settings'] = True
-        request_dict['number_title_list'] = number_title_list
-        request_dict['max_value_dict'] = max_value_dict
-        request_dict['min_value_dict'] = min_value_dict
         return render(request, 'general/parameter_custom.html', request_dict)
     
     @method_decorator(login_required)
     def post(self, request, *arg, **kwargs):
-        parser = JsonParser()
-        path = Path()
-        number_data_frame = NumberDataframe()
-        
-        string_element_dict = {} # column_title - element
-        username = request.user.get_username()
         file_name = kwargs.get('csv_name')
-        title_id_pair = request.POST.get('title_id_pair', None)
+        if not file_name:
+            return redirect('home')
             
-        caller = path.get_caller(request)
-        
-        file_path = path.get_upload_path(request, file_name, caller=caller)
-        string_element_dict = parser.get_file_string_element(file_path)
-        number_title_list = number_data_frame.get_number_title(file_path)
-        max_value_dict, min_value_dict = number_data_frame.get_number_limit(file_path, number_title_list)
-           
-        request_dict = {}
-        request_dict = self.set_url_path(request_dict, caller, file_name)  
-        request_dict['string_element_dict'] = string_element_dict
-        request_dict['file_name'] = file_name
-        request_dict['custom_mode'] = 'json_parser'
-        request_dict['caller'] = caller
+        title_id_pair = request.POST.get('title_id_pair', None)            
+        request_dict = self.get_request_dict(request, *arg, **kwargs)
         request_dict['title_id_pair'] = title_id_pair
+        return render(request, 'general/parameter_custom.html', request_dict)
+        
+    def get_request_dict(self, request, *arg, **kwargs):
+        path = Path()
+        
+        file_name = kwargs.get('csv_name')            
+        caller = path.get_caller(request) 
+        
+        file_path = path.get_upload_path(request, file_name, caller=caller)        
+        number_data_frame = NumberDataframe(file_path)
+        number_title_list = number_data_frame.get_number_title()
+        number_type_pair = number_data_frame.get_number_type_pair(number_title_list)
+        max_value_dict, min_value_dict = number_data_frame.get_number_limit(number_title_list, number_type_pair=number_type_pair)
+           
+        request_dict = super().get_request_dict(request, *arg, **kwargs)
         request_dict['advanced_settings'] = True
         request_dict['number_title_list'] = number_title_list
+        request_dict['number_type_pair'] = number_type_pair
         request_dict['max_value_dict'] = max_value_dict
         request_dict['min_value_dict'] = min_value_dict
-        return render(request, 'general/parameter_custom.html', request_dict)
+        return request_dict


### PR DESCRIPTION
錯誤原因：
1. 取得 DOM 的 value 後沒有進行型態轉換

調整項目：
1. 後台傳遞欄位的型態給前台以做轉換
2. 藉由取得的型態，避免自動生成數值區間時變為浮點數

備註：
1. pandas的read_csv當整數欄位有空值時，會錯誤解讀為float
2. 新版的pandas有推出Int64，或許可解決該問題

issue #207