### PR TITLE
hotfix: 修復確認密碼時無法切換語言的bug

### DIFF
--- a/Template/general/function.html
+++ b/Template/general/function.html
@@ -122,7 +122,9 @@
                     return;
                 }
                 if (request.finish == true) {
-                    window.location = request.url;
+                    var mm = window.setInterval("check_time()", 1000);
+                    var sitv = window.setInterval("progress_check()", 10000);
+                    success(sitv, mm);
                 } else if (request.finish == false) {
                     reset();
                     execute_jquary.attr('disabled', 'disabled');

--- a/Template/general/function_home.html
+++ b/Template/general/function_home.html
@@ -35,34 +35,11 @@
                     var url = "{% url 'initialize' %}"
                     $.get(url);
                 } else if (request.finish == true) {
-                    next = true
-                    while (next) {
-                        if (confirm("{% trans '檔案去識別化完成，是否查看執行結果?' %}")) {
-                            next = false
-                            window.location = request.url;
-                        } else {
-                            if (confirm("{% trans '確定執行新的去識別化嗎?先前的執行結果將不會保留' %}")) {
-                                next = false
-                                $.get("{% url 'initialize' %}");
-                            }
-                        }
-                    }
+                    window.location = "{% url 'file_finish' %}";
                 } else if (request.finish == false) {
-                    next = true
-                    while (next) {
-                        if (confirm("{% trans '檔案執行中，是否查看執行進度?' %}")) {
-                            next = false
-                            window.location = request.url;
-                        } else {
-                            if (confirm("{% trans '確定執行新的去識別化嗎?先前的執行進度將不會保留' %}")) {
-                                next = false
-                                $.get(request.break_url);
-                                $.get("{% url 'initialize' %}");
-                            }
-                        }
-                    }
+                    window.location = "{% url 'file_running' %}";
                 } else {
-                    alert("{% trans 'home.html finish不符合預期，請通知開發人員，finish = ' %}"+request.finish);
+                    alert("{% trans 'function_home.html finish不符合預期，請通知開發人員，finish = ' %}"+request.finish);
                 }
             })
         })        

--- a/Template/general/update_log_text.html
+++ b/Template/general/update_log_text.html
@@ -1,5 +1,9 @@
 {% load i18n %}
-<cell cell_title="{% trans '最新更新 9/15 ver 1.8.4' %}">
+<cell cell_title="{% trans '最新更新 9/16 ver 1.8.5' %}">
+    <h4 style="font-weight:bold;color:red">{% trans '調整項目：' %}</h5>
+    <h5 style="font-weight:bold;color:red">{% trans '1. 修復在密碼確認頁面/是否接續去識別化執行頁面中，切換語言將會引發錯誤的 bug' %}</h5>
+</cell>
+<cell cell_title="9/15 ver 1.8.4">
     <h4 style="font-weight:bold;color:red">{% trans '調整項目：' %}</h5>
     <h5 style="font-weight:bold;color:red">{% trans '1. 在本機檢查檔案大小是否符合條件，加速判斷速度' %}</h5>
 </cell>

--- a/Template/home.html
+++ b/Template/home.html
@@ -28,6 +28,7 @@
         $(function () {
             sidebar_highlight('home');
         })
+        
         $(function () {
             var url = "{% url 'check_file_status' %}"
             $.getJSON(url, function (request) {
@@ -35,18 +36,9 @@
                     url = "{% url 'initialize' %}";
                     $.get(url);
                 } else if (request.finish == true) {
-                    url = "{% url 'file_finish' %}";
-                    var data = {
-                        'yes_url' : request.url,
-                    }
-                    post_to_url(url,data);
+                    window.location = "{% url 'file_finish' %}";
                 } else if (request.finish == false) {
-                    url = "{% url 'file_running' %}";
-                    var data = {
-                        'yes_url' : request.url,
-                        'break_url' : request.break_url,
-                    }
-                    post_to_url(url,data);
+                    window.location = "{% url 'file_running' %}";
                 } else {
                     alert("{% trans 'home.html finish不符合預期，請通知開發人員，finish = ' %}"+request.finish);
                 }

--- a/Template/navbar.html
+++ b/Template/navbar.html
@@ -87,13 +87,7 @@
             warning_alert("{% trans '請先登入' %}");
             return;
         {% endif %}
-        var url = "{% url 'password_check_page' %}";
-        var data = {
-            'csrfmiddlewaretoken' : '{{ csrf_token }}',
-            'cell_content' : "{% trans '帳號即將刪除，刪除後資料無法回復，如確定要刪除請輸入密碼' %}",
-            'check_success_action_url' : "{% url 'delete_account' %}",
-        };
-        post_to_url(url, data);        
+        window.location = "{% url 'password_check_page' 'delete_account' %}";
     }
     
     function change_password() {
@@ -101,12 +95,6 @@
             warning_alert("{% trans '請先登入' %}");
             return;
         {% endif %}
-        var url = "{% url 'password_check_page' %}";
-        var data = {
-            'csrfmiddlewaretoken' : '{{ csrf_token }}',
-            'cell_content' : "{% trans '請輸入原本的密碼，以繼續進行密碼更改' %}",
-            'check_success_action_url' : "{% url 'change_password' %}",
-        };
-        post_to_url(url, data);        
+        window.location = "{% url 'password_check_page' 'change_password' %}";
     }
 </script>

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     path('delete_account/', views.DeleteAccountView.as_view(), name = 'delete_account'),
     path('change_password/', views.ChangePasswordView.as_view(), name = 'change_password'),
     path('password_check/', views.PasswordCheckView.as_view(), name = 'password_check'),
-    path('password_check_page/', views.PasswordCheckPageView.as_view(), name = 'password_check_page'),
+    path('password_check_page/<str:mode>/', views.PasswordCheckPageView.as_view(), name = 'password_check_page'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -8,6 +8,8 @@ from django.contrib import auth
 from django.views import View
 from django.conf import settings
 from django.utils.translation import gettext
+from django.urls import reverse
+
 from accounts.forms import TwUserCreationForm, ChangePasswordForm
 import os
 import shutil
@@ -106,9 +108,17 @@ class PasswordCheckView(View):
         
 class PasswordCheckPageView(View):
     @method_decorator(login_required)
-    def post(self, request, *arg, **kwargs):
-        cell_content = request.POST.get('cell_content', None)
-        check_success_action_url = request.POST.get('check_success_action_url', None)        
+    def get(self, request, *arg, **kwargs):
+        mode = kwargs.get('mode')
+        
+        if mode == 'delete_account':
+            cell_content = gettext('帳號即將刪除，刪除後資料無法回復，如確定要刪除請輸入密碼')
+            check_success_action_url = reverse('delete_account')
+        elif mode == 'change_password':
+            cell_content = gettext('請輸入原本的密碼，以繼續進行密碼更改')
+            check_success_action_url = reverse('change_password')
+        else:
+            raise Exception('PasswordCheckPageView mode error mode : '+mode)
         
         request_dict = {}
         request_dict['cell_content'] = cell_content

--- a/general/views.py
+++ b/general/views.py
@@ -215,19 +215,12 @@ class AbstractMethodView(View):
 class CheckFileStatus(View):
     @method_decorator(login_required)
     def get(self, request, *arg, **kwargs):
-        path = Path()
-        
+        path = Path()        
         username = request.user.get_username()
         try:
             file = ExecuteModel.objects.get(user_name=username)
-            caller = file.caller
             request_dict = {}
-            request_dict['finish'] = file.finish
-            if file.finish:
-                request_dict['url'] = reverse(caller+':finish', args=[file.file_name])
-            if not file.finish:
-                request_dict['url'] = reverse(caller+':execute_page', args=[file.file_name])
-                request_dict['break_url'] = reverse(caller+':break_program')
+            request_dict['finish'] = file.finish            
             return JsonResponse(request_dict)
         except Exception as e:
             return JsonResponse(None, safe=False)
@@ -236,8 +229,7 @@ class AbstractBreakProgramView(View):
     @method_decorator(login_required)
     def get(self, request, *arg, **kwargs):
         finish = False
-        username = request.user.get_username()
-        
+        username = request.user.get_username()        
         try:
             file = ExecuteModel.objects.get(user_name=username)
             self.break_program(file)
@@ -412,8 +404,11 @@ class UpdateLogView(View):
 
 class FileFinishView(View):
     @method_decorator(login_required)
-    def post(self, request, *arg, **kwargs):
-        yes_url = request.POST.get('yes_url')
+    def get(self, request, *arg, **kwargs):
+        username = request.user.get_username()
+        file = ExecuteModel.objects.get(user_name=username)
+        caller = file.caller
+        yes_url = reverse(caller+':finish', args=[file.file_name])
     
         request_dict = {}
         request_dict['cell_title'] = gettext('先前檔案去識別化完成')
@@ -423,9 +418,12 @@ class FileFinishView(View):
         
 class FileRunningView(View):
     @method_decorator(login_required)
-    def post(self, request, *arg, **kwargs):
-        yes_url = request.POST.get('yes_url')
-        break_url = request.POST.get('break_url')
+    def get(self, request, *arg, **kwargs):
+        username = request.user.get_username()
+        file = ExecuteModel.objects.get(user_name=username)
+        caller = file.caller
+        yes_url = reverse(caller+':execute_page', args=[file.file_name])
+        break_url = reverse(caller+':break_program')
 
         request_dict = {}
         request_dict['cell_title'] = gettext('已有檔案執行中')


### PR DESCRIPTION
錯誤原因：
1. 切換語言時會發出 Get 請求，但該頁面只接受 Post 請求

調整項目：
1. 將頁面全改為接受 Get 請求
2. 執行頁面有使用到被修改掉的確認檔案狀態時會回傳的url
3. 執行頁面改為使用內建的函式，使用者體驗也較有一致性

issue #266